### PR TITLE
Add dark theme toggle in View menu

### DIFF
--- a/Apps/WinForms/ProjectTreeViewer.WinForms/AppTheme.cs
+++ b/Apps/WinForms/ProjectTreeViewer.WinForms/AppTheme.cs
@@ -1,0 +1,7 @@
+namespace ProjectTreeViewer.WinForms;
+
+public enum AppTheme
+{
+	Light,
+	Dark
+}

--- a/Apps/WinForms/ProjectTreeViewer.WinForms/Form1.Designer.cs
+++ b/Apps/WinForms/ProjectTreeViewer.WinForms/Form1.Designer.cs
@@ -39,6 +39,8 @@ namespace ProjectTreeViewer.WinForms
 			miViewZoomIn = new ToolStripMenuItem();
 			miViewZoomOut = new ToolStripMenuItem();
 			miViewZoomReset = new ToolStripMenuItem();
+			miViewSep2 = new ToolStripSeparator();
+			miViewDarkTheme = new ToolStripMenuItem();
 			miSearch = new ToolStripMenuItem();
 			miOptions = new ToolStripMenuItem();
 			miLanguage = new ToolStripMenuItem();
@@ -155,7 +157,7 @@ namespace ProjectTreeViewer.WinForms
 			// 
 			// miView
 			// 
-			miView.DropDownItems.AddRange(new ToolStripItem[] { miViewExpandAll, miViewCollapseAll, miViewSep1, miViewZoomIn, miViewZoomOut, miViewZoomReset });
+			miView.DropDownItems.AddRange(new ToolStripItem[] { miViewExpandAll, miViewCollapseAll, miViewSep1, miViewZoomIn, miViewZoomOut, miViewZoomReset, miViewSep2, miViewDarkTheme });
 			miView.Name = "miView";
 			miView.Size = new Size(14, 20);
 			// 
@@ -200,6 +202,18 @@ namespace ProjectTreeViewer.WinForms
 			miViewZoomReset.ShortcutKeys = Keys.Control | Keys.D0;
 			miViewZoomReset.Size = new Size(196, 26);
 			miViewZoomReset.Click += miViewZoomReset_Click;
+			// 
+			// miViewSep2
+			// 
+			miViewSep2.Name = "miViewSep2";
+			miViewSep2.Size = new Size(193, 6);
+			// 
+			// miViewDarkTheme
+			// 
+			miViewDarkTheme.CheckOnClick = true;
+			miViewDarkTheme.Name = "miViewDarkTheme";
+			miViewDarkTheme.Size = new Size(196, 26);
+			miViewDarkTheme.CheckedChanged += miViewDarkTheme_CheckedChanged;
 			// 
 			// miSearch
 			// 
@@ -521,6 +535,8 @@ namespace ProjectTreeViewer.WinForms
         private ToolStripMenuItem miViewZoomIn;
         private ToolStripMenuItem miViewZoomOut;
         private ToolStripMenuItem miViewZoomReset;
+        private ToolStripSeparator miViewSep2;
+        private ToolStripMenuItem miViewDarkTheme;
 		private ToolStripMenuItem miSearch;
 
         private ToolStripMenuItem miOptions;

--- a/Apps/WinForms/ProjectTreeViewer.WinForms/Services/ThemeMenuRenderer.cs
+++ b/Apps/WinForms/ProjectTreeViewer.WinForms/Services/ThemeMenuRenderer.cs
@@ -1,0 +1,46 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ProjectTreeViewer.WinForms.Services;
+
+public sealed class ThemeMenuRenderer : ToolStripProfessionalRenderer
+{
+	private readonly ThemePalette _palette;
+
+	public ThemeMenuRenderer(ThemePalette palette) : base(new ThemeMenuColorTable(palette))
+	{
+		_palette = palette;
+	}
+
+	protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
+	{
+		using var pen = new Pen(_palette.MenuBorder);
+		var bounds = new Rectangle(0, 0, e.ToolStrip.Width - 1, e.ToolStrip.Height - 1);
+		e.Graphics.DrawRectangle(pen, bounds);
+	}
+}
+
+public sealed class ThemeMenuColorTable : ProfessionalColorTable
+{
+	private readonly ThemePalette _palette;
+
+	public ThemeMenuColorTable(ThemePalette palette)
+	{
+		_palette = palette;
+		UseSystemColors = false;
+	}
+
+	public override Color ToolStripDropDownBackground => _palette.MenuBackground;
+	public override Color MenuBorder => _palette.MenuBorder;
+	public override Color MenuItemBorder => _palette.MenuBorder;
+	public override Color MenuItemSelected => _palette.MenuSelection;
+	public override Color MenuItemSelectedGradientBegin => _palette.MenuSelection;
+	public override Color MenuItemSelectedGradientEnd => _palette.MenuSelection;
+	public override Color MenuItemPressedGradientBegin => _palette.MenuSelection;
+	public override Color MenuItemPressedGradientEnd => _palette.MenuSelection;
+	public override Color ImageMarginGradientBegin => _palette.MenuBackground;
+	public override Color ImageMarginGradientMiddle => _palette.MenuBackground;
+	public override Color ImageMarginGradientEnd => _palette.MenuBackground;
+	public override Color SeparatorDark => _palette.MenuBorder;
+	public override Color SeparatorLight => _palette.MenuBorder;
+}

--- a/Apps/WinForms/ProjectTreeViewer.WinForms/Services/ThemePalette.cs
+++ b/Apps/WinForms/ProjectTreeViewer.WinForms/Services/ThemePalette.cs
@@ -1,0 +1,77 @@
+using System.Drawing;
+
+namespace ProjectTreeViewer.WinForms.Services;
+
+public sealed class ThemePalette
+{
+	public static ThemePalette Light { get; } = new(
+		formBackground: SystemColors.Control,
+		panelBackground: SystemColors.ControlLight,
+		surfaceBackground: SystemColors.Window,
+		menuBackground: SystemColors.Control,
+		menuSelection: SystemColors.Highlight,
+		menuBorder: SystemColors.ControlDark,
+		textPrimary: SystemColors.ControlText,
+		textMuted: SystemColors.GrayText,
+		buttonBackground: SystemColors.ControlLight,
+		inputBackground: SystemColors.Window,
+		border: SystemColors.ControlDark,
+		treeLine: SystemColors.ControlDark
+	);
+
+	public static ThemePalette Dark { get; } = new(
+		formBackground: Color.FromArgb(30, 30, 30),
+		panelBackground: Color.FromArgb(37, 37, 38),
+		surfaceBackground: Color.FromArgb(30, 30, 30),
+		menuBackground: Color.FromArgb(45, 45, 48),
+		menuSelection: Color.FromArgb(62, 62, 66),
+		menuBorder: Color.FromArgb(63, 63, 70),
+		textPrimary: Color.FromArgb(241, 241, 241),
+		textMuted: Color.FromArgb(200, 200, 200),
+		buttonBackground: Color.FromArgb(51, 51, 55),
+		inputBackground: Color.FromArgb(31, 31, 31),
+		border: Color.FromArgb(63, 63, 70),
+		treeLine: Color.FromArgb(63, 63, 70)
+	);
+
+	public Color FormBackground { get; }
+	public Color PanelBackground { get; }
+	public Color SurfaceBackground { get; }
+	public Color MenuBackground { get; }
+	public Color MenuSelection { get; }
+	public Color MenuBorder { get; }
+	public Color TextPrimary { get; }
+	public Color TextMuted { get; }
+	public Color ButtonBackground { get; }
+	public Color InputBackground { get; }
+	public Color Border { get; }
+	public Color TreeLine { get; }
+
+	private ThemePalette(
+		Color formBackground,
+		Color panelBackground,
+		Color surfaceBackground,
+		Color menuBackground,
+		Color menuSelection,
+		Color menuBorder,
+		Color textPrimary,
+		Color textMuted,
+		Color buttonBackground,
+		Color inputBackground,
+		Color border,
+		Color treeLine)
+	{
+		FormBackground = formBackground;
+		PanelBackground = panelBackground;
+		SurfaceBackground = surfaceBackground;
+		MenuBackground = menuBackground;
+		MenuSelection = menuSelection;
+		MenuBorder = menuBorder;
+		TextPrimary = textPrimary;
+		TextMuted = textMuted;
+		ButtonBackground = buttonBackground;
+		InputBackground = inputBackground;
+		Border = border;
+		TreeLine = treeLine;
+	}
+}

--- a/Assets/Localization/de.json
+++ b/Assets/Localization/de.json
@@ -16,6 +16,7 @@
   "Menu.View.ZoomIn": "Vergrößern",
   "Menu.View.ZoomOut": "Verkleinern",
   "Menu.View.ZoomReset": "Zoom zurücksetzen",
+  "Menu.View.DarkTheme": "Dunkles Thema",
   "Menu.Search": "Suche",
 
   "Menu.Options": "Optionen",

--- a/Assets/Localization/en.json
+++ b/Assets/Localization/en.json
@@ -13,6 +13,7 @@
   "Menu.View.ZoomIn": "Zoom in",
   "Menu.View.ZoomOut": "Zoom out",
   "Menu.View.ZoomReset": "Reset zoom",
+  "Menu.View.DarkTheme": "Dark theme",
   "Menu.Search": "Search",
   "Menu.Options": "Options",
   "Menu.Options.TreeSettings": "Tree settings",

--- a/Assets/Localization/fr.json
+++ b/Assets/Localization/fr.json
@@ -16,6 +16,7 @@
   "Menu.View.ZoomIn": "Agrandir",
   "Menu.View.ZoomOut": "Rétrécir",
   "Menu.View.ZoomReset": "Réinitialiser le zoom",
+  "Menu.View.DarkTheme": "Thème sombre",
   "Menu.Search": "Recherche",
 
   "Menu.Options": "Options",

--- a/Assets/Localization/it.json
+++ b/Assets/Localization/it.json
@@ -16,6 +16,7 @@
   "Menu.View.ZoomIn": "Zoom avanti",
   "Menu.View.ZoomOut": "Zoom indietro",
   "Menu.View.ZoomReset": "Reimposta zoom",
+  "Menu.View.DarkTheme": "Tema scuro",
   "Menu.Search": "Ricerca",
 
   "Menu.Options": "Opzioni",

--- a/Assets/Localization/kk.json
+++ b/Assets/Localization/kk.json
@@ -16,6 +16,7 @@
   "Menu.View.ZoomIn": "Үлкейту",
   "Menu.View.ZoomOut": "Кішірейту",
   "Menu.View.ZoomReset": "Масштабты қалпына келтіру",
+  "Menu.View.DarkTheme": "Қараңғы тақырып",
   "Menu.Search": "Іздеу",
 
   "Menu.Options": "Параметрлер",

--- a/Assets/Localization/ru.json
+++ b/Assets/Localization/ru.json
@@ -16,6 +16,7 @@
   "Menu.View.ZoomIn": "Увеличить",
   "Menu.View.ZoomOut": "Уменьшить",
   "Menu.View.ZoomReset": "Сбросить масштаб",
+  "Menu.View.DarkTheme": "Темная тема",
   "Menu.Search": "Поиск",
 
   "Menu.Options": "Параметры",

--- a/Assets/Localization/tg.json
+++ b/Assets/Localization/tg.json
@@ -16,6 +16,7 @@
   "Menu.View.ZoomIn": "Калон кардан",
   "Menu.View.ZoomOut": "Хурд кардан",
   "Menu.View.ZoomReset": "Барқарор кардани миқёс",
+  "Menu.View.DarkTheme": "Мавзӯи торик",
   "Menu.Search": "Ҷустуҷӯ",
 
   "Menu.Options": "Танзимот",

--- a/Assets/Localization/uz.json
+++ b/Assets/Localization/uz.json
@@ -16,6 +16,7 @@
   "Menu.View.ZoomIn": "Kattalashtirish",
   "Menu.View.ZoomOut": "Kichiklashtirish",
   "Menu.View.ZoomReset": "Masshtabni tiklash",
+  "Menu.View.DarkTheme": "Qorong‘i mavzu",
   "Menu.Search": "Qidirish",
 
   "Menu.Options": "Sozlamalar",


### PR DESCRIPTION
### Motivation
- Provide an adequate dark theme for the WinForms UI while preserving the project architecture and behavior. 
- Allow users to switch the UI palette from the `View` menu with a simple, discoverable toggle. 

### Description
- Add a `Dark theme` checkable item to the `View` menu and wire it to `miViewDarkTheme_CheckedChanged` to toggle themes. 
- Introduce `AppTheme` enum, `ThemePalette` (light/dark color sets) and `ThemeMenuRenderer` to centralize palette data and menu rendering. 
- Implement theme application logic in `Form1`: `ApplyTheme`, `SetTheme`, menu/toolstrip/menu-item styling and `ApplyThemeToControl` to propagate colors to `panelSettings`, `treeProject`, toolstrip search and other controls, and protect toggle feedback with `_suppressThemeToggle`. 
- Add localized label `Menu.View.DarkTheme` to the localization catalogs for all supported languages. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e85a9eea88330bd679b053c004274)