### PR TITLE
Clarify BSL Additional Use Grant and add contribution bullets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to ProjectTreeViewer
+
+Thanks for your interest in improving ProjectTreeViewer! This guide is intentionally lightweight.
+
+## Build and run
+
+From the repository root:
+
+```bash
+dotnet restore
+
+dotnet build
+
+dotnet run --project Apps/Avalonia/ProjectTreeViewer.Avalonia.csproj
+```
+
+## Run tests
+
+```bash
+dotnet test
+```
+
+## What contributions are welcome
+
+* Bug fixes
+* Documentation improvements (README, screenshots, store descriptions)
+* Performance improvements
+* Tests (unit and integration)
+* UI/UX improvements
+* Icon mappings
+* Localization
+
+## Contribution license
+
+By submitting a contribution, you agree that it is licensed under the current project license (BSL 1.1).

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,63 @@
-MIT License
+Business Source License 1.1
 
-Copyright (c) 2025 Avazbek Olimov
+Licensor: Avazbek Olimov
+Licensed Work: ProjectTreeViewer
+The Licensed Work is (c) 2025 Avazbek Olimov
+Additional Use Grant: You may use, copy, modify, and distribute the Licensed Work for
+personal use, non-commercial use, educational use, internal production use (including
+use within companies, teams, and organizations), and reading the source code. You may
+submit issues and pull requests. You may not use the Licensed Work for commercial resale
+of the application or code, offer it as a SaaS or hosted service, or embed it into paid
+or commercial products without explicit written permission from the Licensor.
+Change Date: 2030-01-01
+Change License: MIT
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Terms
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The Licensor hereby grants you the right to copy, modify, create derivative works,
+redistribute, and make non-production use of the Licensed Work. The Licensor may make
+an Additional Use Grant, above, permitting limited production use.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Effective on the Change Date, or the fourth anniversary of the first publicly available
+release of a specific version of the Licensed Work under this License, whichever comes
+first, the Licensor hereby grants you rights under the terms of the Change License, and
+the rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently in
+effect as described in this License, you must purchase a commercial license from the
+Licensor, its affiliated entities, or authorized resellers, or you must refrain from
+using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of the
+Licensed Work, are subject to this License. This License applies separately for each
+version of the Licensed Work and the Change Date may vary for each version of the
+Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of the
+Licensed Work. If you receive the Licensed Work in original or modified form from a
+third party, the terms and conditions set forth in this License apply to your use of
+that work.
+
+Any use of the Licensed Work in violation of this License will automatically terminate
+your rights under this License for the current and all other versions of the Licensed
+Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or its
+affiliates (provided that you may use a trademark or logo of Licensor as expressly
+required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN “AS IS”
+BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED,
+INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+MariaDB hereby grants you permission to use this License’s text and to refer to it using
+the trademark “Business Source License”, as long as you comply with the Covenants of
+Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License’s text and the “Business Source
+License” name and trademark, Licensor covenants to MariaDB, and to all other recipients
+of the licensed work, that Licensor will not modify this License in any other way than
+permitted by this License’s terms.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Avazbek Olimov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -258,27 +258,11 @@ Suggested contributions:
 
 ## License 📄
 
-MIT License
+ProjectTreeViewer is source-available under the Business Source License (BSL) 1.1.
 
-Copyright (c) 2025 Avazbek Olimov
+Non-commercial use and contributions are allowed, while commercial use is restricted until 2030-01-01. On that date, the license automatically changes to MIT.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+See [LICENSE](LICENSE) for the current terms and [LICENSE-MIT](LICENSE-MIT) for the future change license.
 
 ---
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,9 @@
+# Trademarks
+
+ProjectTreeViewer is the name of this project and its user-facing identity.
+
+Forks are welcome, but please use a different name and icon for your releases or store listings.
+
+Please do not use the ProjectTreeViewer name or logo in a way that implies your fork is official.
+
+Thank you for helping keep the ecosystem clear and friendly.


### PR DESCRIPTION
### Motivation

- Make the Business Source License (BSL 1.1) intent explicit by permitting `internal production use` (including use within companies, teams, and organizations) while keeping resale, SaaS, and embedding in paid products restricted. 
- Make contribution guidance clearer by calling out documentation and test contributions in the list of welcomed contributions.

### Description

- Update the `Additional Use Grant` in `LICENSE` to explicitly allow `personal use`, `non-commercial use`, `educational use`, `internal production use (including use within companies, teams, and organizations)`, and `reading the source code`, and to explicitly prohibit `commercial resale`, offering the work as `SaaS`/hosted services, or embedding into paid/commercial products without written permission. 
- Add two bullets to the "What contributions are welcome" section in `CONTRIBUTING.md`: `Documentation improvements (README, screenshots, store descriptions)` and `Tests (unit and integration)`.

### Testing

- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973cbe68f6c8330a42d834edb20cbd9)