### PR TITLE
perf(tree): free search memory on close, stabilize horizontal scroll, debounce bulk select

### DIFF
--- a/Apps/Avalonia/DevProjex.Avalonia/Coordinators/MetricsPipeline.cs
+++ b/Apps/Avalonia/DevProjex.Avalonia/Coordinators/MetricsPipeline.cs
@@ -58,6 +58,11 @@ internal sealed class MetricsPipeline(
 
     private const double CompactStatusMetricsThresholdWidth = 1050;
 
+    // Incremental (single-file) selection changes stay near-instant; bulk directory/root toggles
+    // coalesce into a longer window to keep the UI thread responsive during "select all".
+    private static readonly TimeSpan MetricsDebounceDelay = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan MetricsLargeSelectionDebounceDelay = TimeSpan.FromMilliseconds(300);
+
     private static readonly FrozenSet<string> MetricsWarmupBinaryExtensions =
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -114,20 +119,26 @@ internal sealed class MetricsPipeline(
 
     public bool HasStatusMetricsSnapshot => _hasStatusMetricsSnapshot;
 
-    public void ScheduleRecalculate()
+    public void ScheduleRecalculate(bool largeSelectionChange = false)
     {
         // A parent checkbox can fire hundreds of child change notifications. Keep the
         // debounce timer inside the metrics pipeline so UI code does not own recalc state.
+        //
+        // Bulk directory/root toggles select the whole subtree and make the follow-up metrics
+        // recompute expensive (full-tree text build + large-string/GC pressure). Coalesce those
+        // with a longer window so a deliberate "select all" does not immediately kick heavy work
+        // while the selection cascade is still settling. Single-file toggles keep the near-instant
+        // default so normal selections still feel responsive.
         if (_metricsDebounceTimer is null)
         {
-            _metricsDebounceTimer = new DispatcherTimer
-            {
-                Interval = TimeSpan.FromMilliseconds(50)
-            };
+            _metricsDebounceTimer = new DispatcherTimer();
             _metricsDebounceTimer.Tick += OnMetricsDebounceTimerTick;
         }
 
         _metricsDebounceTimer.Stop();
+        _metricsDebounceTimer.Interval = largeSelectionChange
+            ? MetricsLargeSelectionDebounceDelay
+            : MetricsDebounceDelay;
         _metricsDebounceTimer.Start();
     }
 

--- a/Apps/Avalonia/DevProjex.Avalonia/Coordinators/PreviewWorkspacePipeline.cs
+++ b/Apps/Avalonia/DevProjex.Avalonia/Coordinators/PreviewWorkspacePipeline.cs
@@ -21,7 +21,7 @@ internal sealed class PreviewWorkspacePipeline(
 
     public bool ShouldClearBeforeNextRefresh => _clearBeforeNextRefresh;
 
-    public void ScheduleRefresh(bool immediate = false)
+    public void ScheduleRefresh(bool immediate = false, TimeSpan? debounceOverride = null)
     {
         _refreshRequested = true;
 
@@ -37,6 +37,12 @@ internal sealed class PreviewWorkspacePipeline(
 
         EnsureDebounceTimer();
         _previewDebounceTimer!.Stop();
+        // Rebuilding the preview reads every selected file. Bulk selection changes ("select all")
+        // pass a longer coalescing window so the heavy build waits for the selection to settle,
+        // instead of firing on the default incremental-edit debounce.
+        _previewDebounceTimer.Interval = debounceOverride is { } overrideInterval && overrideInterval > debounceInterval
+            ? overrideInterval
+            : debounceInterval;
         _previewDebounceTimer.Start();
     }
 

--- a/Apps/Avalonia/DevProjex.Avalonia/Coordinators/TreeSearchCoordinator.cs
+++ b/Apps/Avalonia/DevProjex.Avalonia/Coordinators/TreeSearchCoordinator.cs
@@ -54,7 +54,6 @@ public sealed class TreeSearchCoordinator(
     private int _indexedRootCount;
     private int _searchVersion;
     private int _bringIntoViewVersion;
-    private double? _searchNavigationTargetHorizontalOffset;
     private int _searchExpansionEpoch;
     private bool _searchExpansionStateInitialized;
     private const int SearchQueryCacheLimit = 8;
@@ -347,14 +346,15 @@ public sealed class TreeSearchCoordinator(
         }
 
         var node = _searchMatches[_searchMatchIndex];
-        _searchNavigationTargetHorizontalOffset = CaptureTreeHorizontalOffset();
         node.EnsureParentsExpanded();
         SelectTreeNode(node);
         UpdateCurrentSearchMatch(node);
         UpdateSearchMatchSummary();
-        var bringIntoViewVersion = BringNodeIntoView(node);
+        // Horizontal scrolling is disabled on the tree, so search navigation only needs to bring the
+        // match into view vertically. The former horizontal offset capture/restore/re-clamp dance was
+        // the source of the side-scroll jumpiness and is intentionally gone.
+        BringNodeIntoView(node);
         treeView.Focus();
-        RestoreTreeHorizontalOffsetAfterSearchNavigation(bringIntoViewVersion);
     }
 
     private async Task RunSearchAsync(int version, CancellationToken token)
@@ -1100,40 +1100,20 @@ public sealed class TreeSearchCoordinator(
         if (containerTopLeft is null)
             return;
 
-        var horizontalTarget = ResolveTreeItemHorizontalScrollTarget(container);
-        var horizontalTopLeft = horizontalTarget.TranslatePoint(default, scrollViewer) ?? containerTopLeft.Value;
+        // Vertical-only bring-into-view. Horizontal scrolling is disabled on the tree, so the
+        // horizontal offset is left untouched (it stays at 0) and is never read or re-clamped.
         var currentOffset = scrollViewer.Offset;
-        var baseOffsetX = _searchNavigationTargetHorizontalOffset ?? currentOffset.X;
-        var itemLeftAtBaseOffset = currentOffset.X + horizontalTopLeft.X - baseOffsetX;
         var targetY = ResolveVerticalOffsetForSearchNavigation(
             currentOffset.Y,
             containerTopLeft.Value.Y,
             containerTopLeft.Value.Y + container.Bounds.Height,
             scrollViewer.Viewport.Height,
             scrollViewer.Extent.Height);
-        var targetX = ResolveHorizontalOffsetForSearchNavigation(
-            baseOffsetX,
-            itemLeftAtBaseOffset,
-            itemLeftAtBaseOffset + horizontalTarget.Bounds.Width,
-            scrollViewer.Viewport.Width,
-            scrollViewer.Extent.Width);
 
-        _searchNavigationTargetHorizontalOffset = targetX;
-
-        if (Math.Abs(targetX - currentOffset.X) < 0.5 && Math.Abs(targetY - currentOffset.Y) < 0.5)
+        if (Math.Abs(targetY - currentOffset.Y) < 0.5)
             return;
 
-        scrollViewer.Offset = new Vector(targetX, targetY);
-    }
-
-    private static Control ResolveTreeItemHorizontalScrollTarget(TreeViewItem container)
-    {
-        // TreeViewItem can be a stretched row container. Horizontal search navigation must
-        // use the actual row content width, otherwise the tree may side-scroll even when
-        // the visible text/icon block already fits inside the narrow preview tree island.
-        return container.FindDescendantOfType<Control>(
-            includeSelf: false,
-            visual => visual is Control { Name: "TreeItemContent" }) ?? container;
+        scrollViewer.Offset = new Vector(currentOffset.X, targetY);
     }
 
     private bool TryGetContainer(TreeNodeViewModel node, out TreeViewItem? container)
@@ -1188,56 +1168,10 @@ public sealed class TreeSearchCoordinator(
             includeSelf: false,
             visual => visual is ScrollViewer);
 
-    private double? CaptureTreeHorizontalOffset() =>
-        GetTreeScrollViewer()?.Offset.X;
-
-    private void RestoreTreeHorizontalOffsetAfterSearchNavigation(int version)
-    {
-        var targetOffsetX = _searchNavigationTargetHorizontalOffset;
-        if (targetOffsetX is null)
-            return;
-
-        RestoreTreeHorizontalOffset(targetOffsetX.Value);
-
-        treeView.Dispatcher.Post(
-            () => RestoreTreeHorizontalOffsetIfCurrent(version),
-            DispatcherPriority.Render);
-        treeView.Dispatcher.Post(
-            () => RestoreTreeHorizontalOffsetIfCurrent(version),
-            DispatcherPriority.Loaded);
-        treeView.Dispatcher.Post(
-            () => RestoreTreeHorizontalOffsetIfCurrent(version),
-            DispatcherPriority.Background);
-    }
-
-    private void RestoreTreeHorizontalOffsetIfCurrent(int version)
-    {
-        if (version != Volatile.Read(ref _bringIntoViewVersion))
-            return;
-
-        var targetOffsetX = _searchNavigationTargetHorizontalOffset;
-        if (targetOffsetX is null)
-            return;
-
-        RestoreTreeHorizontalOffset(targetOffsetX.Value);
-    }
-
-    private void RestoreTreeHorizontalOffset(double preservedOffsetX)
-    {
-        var scrollViewer = GetTreeScrollViewer();
-        if (scrollViewer is null)
-            return;
-
-        var targetX = ResolveClampedTreeHorizontalOffset(
-            preservedOffsetX,
-            scrollViewer.Extent.Width,
-            scrollViewer.Viewport.Width);
-        if (Math.Abs(scrollViewer.Offset.X - targetX) < 0.5)
-            return;
-
-        scrollViewer.Offset = new Vector(targetX, scrollViewer.Offset.Y);
-    }
-
+    // ResolveClampedTreeHorizontalOffset / ResolveHorizontalOffsetForSearchNavigation are retained as
+    // pure helpers (still covered by unit tests) but are no longer used to drive scrolling: horizontal
+    // scrolling is disabled on the tree, so search navigation never reads or writes the horizontal
+    // offset. Removing that logic eliminated the side-scroll jumpiness during search navigation.
     internal static double ResolveClampedTreeHorizontalOffset(
         double preservedOffsetX,
         double extentWidth,

--- a/Apps/Avalonia/DevProjex.Avalonia/Coordinators/TreeSearchCoordinator.cs
+++ b/Apps/Avalonia/DevProjex.Avalonia/Coordinators/TreeSearchCoordinator.cs
@@ -844,11 +844,10 @@ public sealed class TreeSearchCoordinator(
         }
     }
 
-    private int BringNodeIntoView(TreeNodeViewModel node)
+    private void BringNodeIntoView(TreeNodeViewModel node)
     {
         var version = Interlocked.Increment(ref _bringIntoViewVersion);
         TryBringNodeIntoViewWithRetries(node, version, attempt: 0);
-        return version;
     }
 
     private void SelectTreeNode(TreeNodeViewModel node)
@@ -1168,40 +1167,8 @@ public sealed class TreeSearchCoordinator(
             includeSelf: false,
             visual => visual is ScrollViewer);
 
-    // ResolveClampedTreeHorizontalOffset / ResolveHorizontalOffsetForSearchNavigation are retained as
-    // pure helpers (still covered by unit tests) but are no longer used to drive scrolling: horizontal
-    // scrolling is disabled on the tree, so search navigation never reads or writes the horizontal
-    // offset. Removing that logic eliminated the side-scroll jumpiness during search navigation.
-    internal static double ResolveClampedTreeHorizontalOffset(
-        double preservedOffsetX,
-        double extentWidth,
-        double viewportWidth)
-    {
-        var maxX = Math.Max(0, extentWidth - viewportWidth);
-        return Math.Clamp(preservedOffsetX, 0, maxX);
-    }
-
-    internal static double ResolveHorizontalOffsetForSearchNavigation(
-        double currentOffsetX,
-        double itemLeft,
-        double itemRight,
-        double viewportWidth,
-        double extentWidth)
-    {
-        const double tolerance = 1.0;
-        if (viewportWidth <= 0 ||
-            itemLeft >= -tolerance && itemRight <= viewportWidth + tolerance)
-        {
-            return ResolveClampedTreeHorizontalOffset(currentOffsetX, extentWidth, viewportWidth);
-        }
-
-        var targetX = itemLeft < 0
-            ? currentOffsetX + itemLeft
-            : currentOffsetX + itemRight - viewportWidth;
-
-        return ResolveClampedTreeHorizontalOffset(targetX, extentWidth, viewportWidth);
-    }
-
+    // Horizontal scrolling is disabled on the tree, so search navigation only adjusts the vertical
+    // offset. The former horizontal offset helpers were removed along with that logic.
     internal static double ResolveVerticalOffsetForSearchNavigation(
         double currentOffsetY,
         double itemTop,

--- a/Apps/Avalonia/DevProjex.Avalonia/MainWindow.RefreshTreeHost.cs
+++ b/Apps/Avalonia/DevProjex.Avalonia/MainWindow.RefreshTreeHost.cs
@@ -122,6 +122,17 @@ public partial class MainWindow : IRefreshTreePipelineHost
         _viewModel.TreeNodes.Add(root);
         root.IsExpanded = true;
 
+        // Re-apply a checkbox selection captured before a search-close rebuild. This runs synchronously
+        // (no awaits) right after the fresh root is installed and BEFORE _metrics.Recalculate() /
+        // SchedulePreviewRefresh below, so those compute once against the correct selection instead of
+        // an empty (== whole project) one — no empty flash, no double build. Any refresh that reaches
+        // this point honors the pending set, which also preserves selection across a superseding rebuild.
+        if (_pendingCheckedPathsToRestore is { Count: > 0 } pendingChecks)
+        {
+            RestoreCheckedPaths(pendingChecks);
+            _pendingCheckedPathsToRestore = null;
+        }
+
         if (!interactiveFilter && !string.IsNullOrWhiteSpace(input.NameFilter) && root.Children.Count == 0)
             _toastService.Show(_localization["Toast.NoMatches"]);
 

--- a/Apps/Avalonia/DevProjex.Avalonia/MainWindow.axaml
+++ b/Apps/Avalonia/DevProjex.Avalonia/MainWindow.axaml
@@ -575,6 +575,7 @@
                                             ItemsSource="{Binding TreeNodes}"
                                             IsEnabled="{Binding IsProjectLoaded}"
                                             Padding="0,0,0,4"
+                                            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                             FontFamily="{Binding SelectedFontFamily}"
                                             FontSize="{Binding TreeFontSize}">
                     <controls:ProjectTreeView.ItemsPanel>
@@ -590,30 +591,43 @@
                             <ColumnDefinition Width="{CompiledBinding IndentWidth}" />
                             <ColumnDefinition Width="*" />
                           </Grid.ColumnDefinitions>
-                          <StackPanel Grid.Column="1"
-                                      Name="TreeItemContent"
-                                      Orientation="Horizontal"
-                                      Background="Transparent"
-                                      Spacing="{DynamicResource TreeItemSpacingResource}">
-                            <CheckBox IsThreeState="True"
-                                      IsChecked="{CompiledBinding IsChecked, Mode=TwoWay}"
-                                      VerticalAlignment="Center" />
-                            <Image Source="{CompiledBinding Icon}"
-                                   Width="{DynamicResource TreeIconSizeResource}"
-                                   Height="{DynamicResource TreeIconSizeResource}"
-                                   Stretch="Uniform"
-                                   VerticalAlignment="Center" />
-                            <TextBlock Text="{CompiledBinding DisplayName}"
+                          <Grid Grid.Column="1"
+                                Name="TreeItemContent"
+                                Background="Transparent"
+                                ColumnDefinitions="Auto,*">
+                            <StackPanel Grid.Column="0"
+                                        Orientation="Horizontal"
+                                        Background="Transparent"
+                                        Spacing="{DynamicResource TreeItemSpacingResource}">
+                              <CheckBox IsThreeState="True"
+                                        IsChecked="{CompiledBinding IsChecked, Mode=TwoWay}"
+                                        VerticalAlignment="Center" />
+                              <Image Source="{CompiledBinding Icon}"
+                                     Width="{DynamicResource TreeIconSizeResource}"
+                                     Height="{DynamicResource TreeIconSizeResource}"
+                                     Stretch="Uniform"
+                                     VerticalAlignment="Center" />
+                            </StackPanel>
+                            <!-- Name cell fills the remaining viewport width and trims long names.
+                                 Horizontal scrolling is disabled, so the cell is bounded and the
+                                 ellipsis takes over; the full path is shown on hover. -->
+                            <TextBlock Grid.Column="1"
+                                       Text="{CompiledBinding DisplayName}"
                                        IsVisible="{Binding !HasHighlightedDisplay}"
                                        VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"
+                                       ToolTip.Tip="{CompiledBinding FullPath}"
                                        Margin="{DynamicResource TreeTextMarginResource}"
                                        Foreground="{DynamicResource AppTextBrush}" />
-                            <TextBlock Inlines="{CompiledBinding DisplayInlines}"
+                            <TextBlock Grid.Column="1"
+                                       Inlines="{CompiledBinding DisplayInlines}"
                                        IsVisible="{Binding HasHighlightedDisplay}"
                                        VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"
+                                       ToolTip.Tip="{CompiledBinding FullPath}"
                                        Margin="{DynamicResource TreeTextMarginResource}"
                                        Foreground="{DynamicResource AppTextBrush}" />
-                          </StackPanel>
+                          </Grid>
                         </Grid>
                       </TreeDataTemplate>
                     </controls:ProjectTreeView.ItemTemplate>

--- a/Apps/Avalonia/DevProjex.Avalonia/MainWindow.axaml
+++ b/Apps/Avalonia/DevProjex.Avalonia/MainWindow.axaml
@@ -592,7 +592,6 @@
                             <ColumnDefinition Width="*" />
                           </Grid.ColumnDefinitions>
                           <Grid Grid.Column="1"
-                                Name="TreeItemContent"
                                 Background="Transparent"
                                 ColumnDefinitions="Auto,*">
                             <StackPanel Grid.Column="0"

--- a/Apps/Avalonia/DevProjex.Avalonia/MainWindow.axaml.cs
+++ b/Apps/Avalonia/DevProjex.Avalonia/MainWindow.axaml.cs
@@ -211,6 +211,9 @@ public partial class MainWindow : Window
     private VirtualizedPreviewTextControl? _previewTextControl;
     private VirtualizedLineNumbersControl? _previewLineNumbersControl;
     private HashSet<string>? _filterExpansionSnapshot;
+    // Checkbox selection captured before a search-close rebuild, re-applied atomically inside
+    // ApplyTreeRefreshResult (right after the fresh root is installed, before metrics/preview fire).
+    private HashSet<string>? _pendingCheckedPathsToRestore;
     private int _filterApplyVersion;
     private SuspendedTreeToolMode _previewOnlySuspendedTreeToolMode;
     private CancellationTokenSource? _projectOperationCts;
@@ -7119,7 +7122,10 @@ public partial class MainWindow : Window
             // GetCheckedPaths returns the compact, disjoint minimal set (a fully-checked directory
             // appears once; a checked dir never coexists with its descendants), so replaying it later
             // realizes only the ancestor chains of actually-checked items, not the whole tree.
-            var restoreCheckedPaths = GetCheckedPaths();
+            // ApplyTreeRefreshResult re-applies this atomically, right after installing the fresh root
+            // and BEFORE metrics/preview fire, so they never compute against an empty (== whole project)
+            // selection and there is no empty-flash / double build.
+            _pendingCheckedPathsToRestore = GetCheckedPaths();
 
             // Opening search lazily realizes the ENTIRE view-model graph to build the flat search
             // index. Normalizing in place (UpdateSearchMatches on an empty query) only collapses
@@ -7131,22 +7137,23 @@ public partial class MainWindow : Window
             // fresh lazy root. This resets expansion to the base lazy tree (only the root expanded),
             // matching the prior search-close behavior (collapse-all-except-root) while now actually
             // freeing the graph so the scheduled cleanup below can return the memory to the OS.
-            var rebuilt = false;
             try
             {
                 await RefreshTreeAsync(interactiveFilter: true);
-                rebuilt = true;
             }
             catch (OperationCanceledException)
             {
                 // A newer tree refresh superseded the search-close rebuild.
             }
-
-            // The rebuild produces fresh, unchecked view-models. Restore the user's checkbox selection
-            // onto the new lazy root — but only on the success path (a superseded/cancelled rebuild is
-            // handled by whichever newer refresh replaced it, so we must not race it here).
-            if (rebuilt)
-                RestoreCheckedPaths(restoreCheckedPaths);
+            catch (Exception ex)
+            {
+                await ShowErrorAsync(ex.Message);
+            }
+            finally
+            {
+                // Never let a pending restore leak into a later, unrelated refresh.
+                _pendingCheckedPathsToRestore = null;
+            }
 
             ScheduleBackgroundMemoryCleanup(MemoryCleanupReason.SearchClose);
         }
@@ -9048,9 +9055,17 @@ public partial class MainWindow : Window
         if (descendantPath.Length <= ancestorPath.Length)
             return false;
 
-        var boundary = descendantPath[ancestorPath.Length];
-        if (boundary != Path.DirectorySeparatorChar && boundary != Path.AltDirectorySeparatorChar)
-            return false;
+        // A filesystem/drive root ("/" or "C:\") already ends in a separator, so the next character
+        // in the descendant is a real path segment rather than the boundary separator. Only require an
+        // explicit separator boundary when the ancestor does not already end in one.
+        var ancestorEndsWithSep = ancestorPath.Length > 0 &&
+            (ancestorPath[^1] == Path.DirectorySeparatorChar || ancestorPath[^1] == Path.AltDirectorySeparatorChar);
+        if (!ancestorEndsWithSep)
+        {
+            var boundary = descendantPath[ancestorPath.Length];
+            if (boundary != Path.DirectorySeparatorChar && boundary != Path.AltDirectorySeparatorChar)
+                return false;
+        }
 
         return descendantPath.StartsWith(ancestorPath, TreePathStringComparison);
     }

--- a/Apps/Avalonia/DevProjex.Avalonia/MainWindow.axaml.cs
+++ b/Apps/Avalonia/DevProjex.Avalonia/MainWindow.axaml.cs
@@ -343,6 +343,11 @@ public partial class MainWindow : Window
 
     private int _previewSelectionMetricsVersion;
     private static readonly TimeSpan PreviewSelectionMetricsDebounceInterval = UiTimingProfile.Scale(TimeSpan.FromMilliseconds(80));
+
+    // Longer preview coalescing window used when a directory/root toggle changes the selection in
+    // bulk. Keeps the heavy "read every selected file" build from firing on the incremental debounce
+    // while a "select all" cascade is still settling.
+    private static readonly TimeSpan LargeSelectionPreviewDebounce = UiTimingProfile.Scale(TimeSpan.FromMilliseconds(700));
     private ExportOutputMetrics _lastPreviewSelectionMetrics = ExportOutputMetrics.Empty;
     private bool _hasPreviewSelectionMetricsSnapshot;
 
@@ -2886,9 +2891,9 @@ public partial class MainWindow : Window
         }
     }
 
-    private void SchedulePreviewRefresh(bool immediate = false)
+    private void SchedulePreviewRefresh(bool immediate = false, TimeSpan? debounceOverride = null)
     {
-        _previewPipeline.ScheduleRefresh(immediate);
+        _previewPipeline.ScheduleRefresh(immediate, debounceOverride);
     }
 
     private void CancelPreviewRefresh()
@@ -7109,12 +7114,40 @@ public partial class MainWindow : Window
         {
             _viewModel.SearchQuery = string.Empty;
             _searchCoordinator.CancelPending();
-            // Project load clears search state ahead of time. Skip the expensive tree-wide search
-            // normalization when there is no active query or cached match state to restore.
-            if (!string.IsNullOrWhiteSpace(_viewModel.SearchQuery) || _searchCoordinator.HasMatches)
-                _searchCoordinator.UpdateSearchMatches();
 
-            // Release stale highlight objects after search state is rebuilt.
+            // Capture the user's checkbox selection before the rebuild discards the current graph.
+            // GetCheckedPaths returns the compact, disjoint minimal set (a fully-checked directory
+            // appears once; a checked dir never coexists with its descendants), so replaying it later
+            // realizes only the ancestor chains of actually-checked items, not the whole tree.
+            var restoreCheckedPaths = GetCheckedPaths();
+
+            // Opening search lazily realizes the ENTIRE view-model graph to build the flat search
+            // index. Normalizing in place (UpdateSearchMatches on an empty query) only collapses
+            // nodes; it never frees each node's _children nor clears the flat index / query caches,
+            // so the materialized graph (~1.5 GB on large projects) stayed alive and the compacting
+            // GC in ForceMemoryCleanup reclaimed nothing. Rebuild the tree the same way filter-close
+            // does: RefreshTreeAsync -> ApplyTreeRefreshResult runs ClearSearchState() (clears
+            // _flatNodeIndex + query caches) and ClearRecursive() on every node, then installs a
+            // fresh lazy root. This resets expansion to the base lazy tree (only the root expanded),
+            // matching the prior search-close behavior (collapse-all-except-root) while now actually
+            // freeing the graph so the scheduled cleanup below can return the memory to the OS.
+            var rebuilt = false;
+            try
+            {
+                await RefreshTreeAsync(interactiveFilter: true);
+                rebuilt = true;
+            }
+            catch (OperationCanceledException)
+            {
+                // A newer tree refresh superseded the search-close rebuild.
+            }
+
+            // The rebuild produces fresh, unchecked view-models. Restore the user's checkbox selection
+            // onto the new lazy root — but only on the success path (a superseded/cancelled rebuild is
+            // handled by whichever newer refresh replaced it, so we must not race it here).
+            if (rebuilt)
+                RestoreCheckedPaths(restoreCheckedPaths);
+
             ScheduleBackgroundMemoryCleanup(MemoryCleanupReason.SearchClose);
         }
         else
@@ -8948,6 +8981,80 @@ public partial class MainWindow : Window
             root.IsExpanded = true;
     }
 
+    // Matches PathComparer.Default's case sensitivity (OrdinalIgnoreCase on Windows, Ordinal elsewhere)
+    // for the segment-aware ancestor test used while resolving a checked path against the tree.
+    private static readonly StringComparison TreePathStringComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Re-applies a captured checkbox selection to the freshly rebuilt (lazy) tree by replaying each
+    /// path as a user-equivalent <see cref="TreeNodeViewModel.IsChecked"/> = true. Reusing the normal
+    /// setter keeps the exact selection cascade/tri-state semantics of a manual click: it flows down to
+    /// still-unrealized children via the deferred check state and recomputes ancestor tri-state upward.
+    /// Only the ancestor chains of actually-checked items are realized, so the memory win of the rebuild
+    /// is preserved. Paths that no longer resolve (project changed) are skipped silently.
+    /// </summary>
+    private void RestoreCheckedPaths(HashSet<string> checkedPaths)
+    {
+        if (checkedPaths.Count == 0)
+            return;
+
+        foreach (var path in checkedPaths)
+        {
+            if (string.IsNullOrEmpty(path))
+                continue;
+
+            var node = FindTreeNodeByPath(path);
+            if (node is not null)
+                node.IsChecked = true;
+        }
+    }
+
+    private TreeNodeViewModel? FindTreeNodeByPath(string path)
+    {
+        // Pick the root that is the target itself or a segment-aware ancestor of it.
+        TreeNodeViewModel? current = null;
+        foreach (var root in _viewModel.TreeNodes)
+        {
+            if (PathComparer.Default.Equals(root.FullPath, path) || IsPathUnder(path, root.FullPath))
+            {
+                current = root;
+                break;
+            }
+        }
+
+        // Descend one level at a time, realizing children lazily, until the exact node is found.
+        while (current is not null && !PathComparer.Default.Equals(current.FullPath, path))
+        {
+            TreeNodeViewModel? next = null;
+            foreach (var child in current.Children)
+            {
+                if (PathComparer.Default.Equals(child.FullPath, path) || IsPathUnder(path, child.FullPath))
+                {
+                    next = child;
+                    break;
+                }
+            }
+
+            current = next;
+        }
+
+        return current;
+    }
+
+    private static bool IsPathUnder(string descendantPath, string ancestorPath)
+    {
+        if (descendantPath.Length <= ancestorPath.Length)
+            return false;
+
+        var boundary = descendantPath[ancestorPath.Length];
+        if (boundary != Path.DirectorySeparatorChar && boundary != Path.AltDirectorySeparatorChar)
+            return false;
+
+        return descendantPath.StartsWith(ancestorPath, TreePathStringComparison);
+    }
+
     /// <summary>
     /// Validates that URL looks like a valid Git repository URL.
     /// Accepts URLs from common Git hosting services (GitHub, GitLab, Bitbucket, etc.)
@@ -9061,11 +9168,18 @@ public partial class MainWindow : Window
 
     private bool IsBackgroundMetricsActive() => _metrics.IsBackgroundActive;
 
-    private void OnTreeNodeCheckedChanged(TreeNodeViewModel _)
+    private void OnTreeNodeCheckedChanged(TreeNodeViewModel node)
     {
         _treeSelectionSnapshotCache.Invalidate();
-        _metrics.ScheduleRecalculate();
-        SchedulePreviewRefresh();
+
+        // Toggling a directory (especially the project root) cascades the check across its whole
+        // subtree, which turns the follow-up metrics recompute and full-project preview rebuild into
+        // heavy work that can starve the render thread. Coalesce those with a longer debounce so a
+        // deliberate "select all" stays responsive; single-file toggles keep the near-instant default.
+        var largeSelectionChange = node.HasChildren;
+        _metrics.ScheduleRecalculate(largeSelectionChange);
+        SchedulePreviewRefresh(
+            debounceOverride: largeSelectionChange ? LargeSelectionPreviewDebounce : null);
     }
 
     private void RenderPreviewSelectionMetrics()

--- a/Apps/Avalonia/DevProjex.Avalonia/ViewModels/TreeNodeViewModel.cs
+++ b/Apps/Avalonia/DevProjex.Avalonia/ViewModels/TreeNodeViewModel.cs
@@ -85,7 +85,9 @@ public sealed class TreeNodeViewModel(
         }
     }
 
-    public string FullPath => Descriptor.FullPath;
+    // Null-safe: ClearRecursive sets Descriptor = null! during teardown, and the tree row's
+    // ToolTip.Tip binding may still evaluate FullPath on a torn-down node.
+    public string FullPath => Descriptor?.FullPath ?? string.Empty;
 
     public bool? IsChecked
     {

--- a/Tests/DevProjex.Tests.Unit/Avalonia/MainWindowPreviewInternalsTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/MainWindowPreviewInternalsTests.cs
@@ -451,6 +451,13 @@ public sealed class MainWindowPreviewInternalsTests
 
         // A shorter/unrelated path is not under it.
         Assert.False(IsUnder(CreatePath("proj", "a"), ancestor));
+
+        // Filesystem/drive-root ancestors already end in a separator ("/" or "C:\"): the next
+        // descendant character is a real segment, not the boundary, so children still resolve.
+        var fsRoot = CreatePath();
+        Assert.True(IsUnder(CreatePath("home"), fsRoot));
+        Assert.True(IsUnder(CreatePath("a.txt"), fsRoot));
+        Assert.False(IsUnder(fsRoot, fsRoot));
     }
 
     private static string CreatePath(params string[] segments)

--- a/Tests/DevProjex.Tests.Unit/Avalonia/MainWindowPreviewInternalsTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/MainWindowPreviewInternalsTests.cs
@@ -423,6 +423,36 @@ public sealed class MainWindowPreviewInternalsTests
             ]);
     }
 
+    [Fact]
+    public void IsPathUnder_UsesSegmentAwareBoundary()
+    {
+        // Guards the search-close selection restore: resolving a checked path against the rebuilt tree
+        // must not treat a name-prefix sibling ("proj/a/bc") as a descendant of "proj/a/b".
+        var method = typeof(MainWindow).GetMethod(
+            "IsPathUnder",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        bool IsUnder(string descendant, string ancestor) =>
+            (bool)method!.Invoke(null, [descendant, ancestor])!;
+
+        var ancestor = CreatePath("proj", "a", "b");
+
+        // Direct and nested descendants are under the ancestor.
+        Assert.True(IsUnder(CreatePath("proj", "a", "b", "c"), ancestor));
+        Assert.True(IsUnder(CreatePath("proj", "a", "b", "c", "d.cs"), ancestor));
+
+        // The ancestor path is not "under" itself.
+        Assert.False(IsUnder(ancestor, ancestor));
+
+        // Siblings that only share a name prefix are NOT under it (segment-aware, not raw StartsWith).
+        Assert.False(IsUnder(CreatePath("proj", "a", "bc"), ancestor));
+        Assert.False(IsUnder(CreatePath("proj", "a", "bcd", "e.cs"), ancestor));
+
+        // A shorter/unrelated path is not under it.
+        Assert.False(IsUnder(CreatePath("proj", "a"), ancestor));
+    }
+
     private static string CreatePath(params string[] segments)
     {
         return OperatingSystem.IsWindows()

--- a/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineWarmupTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/MetricsPipelineWarmupTests.cs
@@ -145,6 +145,67 @@ public sealed class MetricsPipelineWarmupTests
         }
     }
 
+    [AvaloniaFact]
+    public async Task ScheduleRecalculate_UsesLongerDebounceForBulkSelectionChanges()
+    {
+        using var temp = new TemporaryDirectory();
+        var treeRoot = new TreeNodeDescriptor("root", temp.Path, true, false, "folder", []);
+        var currentTree = new BuildTreeResult(treeRoot, RootAccessDenied: false, HadAccessDenied: false, []);
+        var viewModel = CreateViewModel();
+        var status = new StatusOperationCoordinator(
+            viewModel,
+            isBackgroundMetricsActive: () => false,
+            metricsOperationTextProvider: () => viewModel.StatusOperationCalculatingData);
+        var pipeline = new MetricsPipeline(
+            viewModel,
+            CreateLocalization(),
+            new FileContentAnalyzer(),
+            new TreeExportService(),
+            status,
+            currentTreeProvider: () => currentTree,
+            currentPathProvider: () => temp.Path,
+            selectedPathsProvider: () => new HashSet<string>(PathComparer.Default),
+            treeFormatProvider: () => TreeTextFormat.Ascii,
+            exportPathPresentationProvider: () => null,
+            boundsWidthProvider: () => 1400);
+
+        try
+        {
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                // A single-file toggle keeps the near-instant default debounce.
+                pipeline.ScheduleRecalculate(largeSelectionChange: false);
+                var incrementalInterval = GetDebounceInterval(pipeline);
+
+                // A directory/root "select all" toggle coalesces with a longer window.
+                pipeline.ScheduleRecalculate(largeSelectionChange: true);
+                var bulkInterval = GetDebounceInterval(pipeline);
+
+                // Stop the timer so it never fires Recalculate during teardown.
+                GetDebounceTimer(pipeline)?.Stop();
+
+                Assert.Equal(TimeSpan.FromMilliseconds(50), incrementalInterval);
+                Assert.Equal(TimeSpan.FromMilliseconds(300), bulkInterval);
+                Assert.True(bulkInterval > incrementalInterval);
+            });
+        }
+        finally
+        {
+            await Dispatcher.UIThread.InvokeAsync(pipeline.Dispose);
+        }
+    }
+
+    private static DispatcherTimer? GetDebounceTimer(MetricsPipeline pipeline)
+    {
+        var field = typeof(MetricsPipeline).GetField(
+            "_metricsDebounceTimer",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        return field?.GetValue(pipeline) as DispatcherTimer;
+    }
+
+    private static TimeSpan GetDebounceInterval(MetricsPipeline pipeline) =>
+        GetDebounceTimer(pipeline)?.Interval ?? TimeSpan.Zero;
+
     private static TreeNodeDescriptor CreateTree(
         string rootPath,
         string textFile,

--- a/Tests/DevProjex.Tests.Unit/Avalonia/TreeSearchCoordinatorTests.cs
+++ b/Tests/DevProjex.Tests.Unit/Avalonia/TreeSearchCoordinatorTests.cs
@@ -259,51 +259,6 @@ public sealed class TreeSearchCoordinatorTests
 		Assert.Equal(currentOffsetY, targetOffsetY);
 	}
 
-	[Theory]
-	[InlineData(0, 500, 200, 0)]
-	[InlineData(120, 500, 200, 120)]
-	[InlineData(420, 500, 200, 300)]
-	[InlineData(-15, 500, 200, 0)]
-	[InlineData(120, 150, 200, 0)]
-	public void ResolveClampedTreeHorizontalOffset_ReturnsOffsetInsideScrollableRange(
-		double preservedOffsetX,
-		double extentWidth,
-		double viewportWidth,
-		double expectedOffsetX)
-	{
-		var targetOffsetX = TreeSearchCoordinator.ResolveClampedTreeHorizontalOffset(
-			preservedOffsetX,
-			extentWidth,
-			viewportWidth);
-
-		Assert.Equal(expectedOffsetX, targetOffsetX);
-	}
-
-	[Theory]
-	[InlineData(0, 12, 120, 200, 500, 0)]
-	[InlineData(80, 0, 200.5, 200, 500, 80)]
-	[InlineData(120, -30, 90, 200, 500, 90)]
-	[InlineData(120, 160, 260, 200, 500, 180)]
-	[InlineData(10, -50, 90, 200, 500, 0)]
-	[InlineData(260, 170, 260, 200, 500, 300)]
-	public void ResolveHorizontalOffsetForSearchNavigation_OnlyMovesWhenTargetIsHorizontallyClipped(
-		double currentOffsetX,
-		double itemLeft,
-		double itemRight,
-		double viewportWidth,
-		double extentWidth,
-		double expectedOffsetX)
-	{
-		var targetOffsetX = TreeSearchCoordinator.ResolveHorizontalOffsetForSearchNavigation(
-			currentOffsetX,
-			itemLeft,
-			itemRight,
-			viewportWidth,
-			extentWidth);
-
-		Assert.Equal(expectedOffsetX, targetOffsetX);
-	}
-
 	[Fact]
 	public void UpdateSearchMatches_WhenQueryHasNoMatches_ResetsSearchSummary()
 	{


### PR DESCRIPTION
## What & why

Three performance issues reported while working in a large folder.

### 1. ~1.5 GB not released after closing search
Opening search over a large folder forced the entire lazy `TreeNodeViewModel` graph to materialize and never freed it on close — the close path only collapsed nodes (`CollapseAllExceptRoot`) and never called `ClearRecursive`/`ClearSearchState`, so the graph and `TreeSearchCoordinator._flatNodeIndex` stayed rooted and `GC.Collect` reclaimed nothing. (The filter-close path already did this correctly — the leak was search-only.)

Closing search now rebuilds the tree the same way filter-close does (`ClearSearchState` + `ClearRecursive` + fresh lazy root) and then **restores the user's file checkbox selection**: the checked path set is captured before the rebuild and replayed through the normal `IsChecked` setter afterward, so no selection is lost and only checked ancestor chains re-materialize (a checked root restores as a single path → near-zero re-materialization).

### 2. Jumpy horizontal scroll in the tree
The stock virtualizing `TreeView` derived its horizontal extent from only the *realized* rows, so the extent/thumb oscillated while scrolling vertically. Horizontal scrolling is now disabled; long names truncate with an ellipsis and show the full path on hover. The now-moot horizontal-offset re-clamping in search navigation is removed (vertical bring-into-view kept).

### 3. ~1s UI freeze when selecting the root ("select all")
Checking the root selects the whole project and kicked a full preview + file-metrics recompute on a 50 ms debounce, saturating cores and starving Avalonia's render thread. Directory/bulk selection changes now use a longer, adaptive debounce; single-file toggles keep the fast 50 ms path.

## Verification
- `dotnet build` (full solution): **0 warnings, 0 errors**
- `dotnet test` (unit): **7720 passed, 0 failed** (incl. 2 new tests)
- Independent adversarial code review: **no blocker/high/medium findings**

Note: the app could not be run/profiled locally (installed SDK band vs `global.json` pin), so the 1.5 GB figure is derived from the code path, not a profiler run. Fixes were validated by build + full unit suite + review.

## Known minor tradeoff
Fix 3 classifies *every* directory as a "bulk" change (cheap `HasChildren` check), so toggling even a tiny folder also gets the longer preview debounce (~0.7s). Deliberate — sizing a folder accurately without realizing its subtree isn't cheap. Easily tunable to a descendant-count threshold later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsZTM2PyeZkp11Q5fGRgYZ
